### PR TITLE
Simple jwt

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from datetime import timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -27,10 +28,16 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Extension Settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': {
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     },
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
 }
 
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -27,6 +27,12 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': {
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    },
+}
+
 
 # Application definition
 

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('accounts.urls')),
 ]

--- a/main/urls.py
+++ b/main/urls.py
@@ -18,7 +18,9 @@ from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
+    # Admin Site
     path('admin/', admin.site.urls),
+    # Account App Views
     path('', include('accounts.urls')),
     # JWT Views
     path('/token', TokenObtainPairView),

--- a/main/urls.py
+++ b/main/urls.py
@@ -15,8 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('accounts.urls')),
+    # JWT Views
+    path('/token', TokenObtainPairView),
+    path('/refresh', TokenRefreshView),
 ]


### PR DESCRIPTION
### Highlights:
- Added simplejwt views to the root urlconf endpoints at /token and /refresh
- Added rest_framework setting to use simplejwt as the default auth class
- Added simple_jwt setting to extend token lifetimes
- Accidentally added account urlconfig to the core urls. (whoops)